### PR TITLE
Add method for creating new stores through Greenfield API controller

### DIFF
--- a/example/create_store.dart
+++ b/example/create_store.dart
@@ -1,0 +1,9 @@
+import 'package:btcpay_client/btcpay_client.dart';
+
+//ignore_for_file: avoid_print
+
+Future<void> main(List<String> args) async {
+  var client = Client.fromUserAuthenticationToken(
+      'https://testnet.demo.btcpayserver.org/', 'my-user-token');
+  print(await client.createStore('store-from-unit-test'));
+}


### PR DESCRIPTION
This new method is a wrapper for the method to create new stores in the
Greenfield controller in BTCPayServer.